### PR TITLE
Changed for compatitbility with new SwitchAudioSource CLI 1.1.0

### DIFF
--- a/SwitchAudioSource.py
+++ b/SwitchAudioSource.py
@@ -1,5 +1,5 @@
 from subprocess import check_output, call
-from json import dumps
+from json import dumps, loads
 from sys import stdout
 from os import environ
 
@@ -10,17 +10,16 @@ LOOKUP_WARNING = "Error: Could not find SwitchAudioSource"
 
 class AudioSource:
     def __init__(self, description, active):
-        words = description.split(' ')
-        output = words.pop(-1)
-        title = ' '.join(words)
+        audioSourceJSON = loads(description)
 
-        self.uid = title
+        title = audioSourceJSON["name"]
+
+        self.uid = audioSourceJSON["uid"]
         self.title = title
         self.arg = title
         self.autocomplete = title
 
-        self.output = output.find('output') > -1
-        self.input = not self.output
+        self.type = audioSourceJSON["type"]
         self.icon = {"path": "icons/active.png" if active ==
                      title else "icons/inactive.png"}
 
@@ -34,7 +33,7 @@ def get_sources():
     ]).strip()
 
     command_output = check_output([
-        PATH_TO_SWITCH_AUDIO_OUTPUT, '-a', '-t', 'output'
+        PATH_TO_SWITCH_AUDIO_OUTPUT, '-a', '-t', 'output', '-f', 'json'
     ])
 
     return map(lambda line: AudioSource(line, active), command_output.splitlines())

--- a/SwitchAudioSource.py
+++ b/SwitchAudioSource.py
@@ -5,6 +5,8 @@ from os import environ
 
 
 PATH_TO_SWITCH_AUDIO_OUTPUT = environ['SWITCH_AUDIO_SOURCE_PATH']
+BUILT_IN_DEVICE_MIC = environ['BUILT_IN_DEVICE_MIC']
+BUILT_IN_DEVICE_SPEAKER = environ['BUILT_IN_DEVICE_SPEAKER']
 LOOKUP_WARNING = "Error: Could not find SwitchAudioSource"
 
 
@@ -33,7 +35,7 @@ def get_sources():
     ]).strip()
 
     command_output = check_output([
-        PATH_TO_SWITCH_AUDIO_OUTPUT, '-a', '-t', 'output', '-f', 'json'
+        PATH_TO_SWITCH_AUDIO_OUTPUT, '-a', '-f', 'json'
     ])
 
     return map(lambda line: AudioSource(line, active), command_output.splitlines())
@@ -48,10 +50,24 @@ def get_current():
 
 def set_output(device):
     check_output([
-        PATH_TO_SWITCH_AUDIO_OUTPUT, '-s', device
+        PATH_TO_SWITCH_AUDIO_OUTPUT, '-t','output', '-s', device
     ])
     stdout.write(device)
 
+def set_input(device):
+    check_output([
+        PATH_TO_SWITCH_AUDIO_OUTPUT, '-t','input', '-s', device
+    ])
+    stdout.write(device)
+
+def is_default_speaker(device):
+    return BUILT_IN_DEVICE_SPEAKER == device
+
+def get_built_in_microphone():
+    return BUILT_IN_DEVICE_MIC
+
+def get_built_in_speaker():
+    return BUILT_IN_DEVICE_SPEAKER
 
 def no_path_provided():
     stdout.write(dumps({

--- a/info.plist
+++ b/info.plist
@@ -575,9 +575,11 @@ Once installed, make sure that the "Environment Variable" that points to the exe
 	<array>
 		<string>LAST_OUTPUT</string>
 		<string>SWITCH_AUDIO_SOURCE_PATH</string>
+		<string>BUILT_IN_DEVICE_MIC</string>
+		<string>BUILT_IN_DEVICE_SPEAKER</string>
 	</array>
 	<key>version</key>
-	<string>1.2.0</string>
+	<string>1.3.0</string>
 	<key>webaddress</key>
 	<string></string>
 </dict>

--- a/list_sources.py
+++ b/list_sources.py
@@ -5,7 +5,7 @@ from json import dumps
 from SwitchAudioSource import get_sources
 
 
-output_items = filter(lambda source: source.output, get_sources())
+output_items = filter(lambda source: source.type == "output", get_sources())
 items = map(lambda source: source.__dict__, output_items)
 
 json_output = dumps({

--- a/set_output_source.py
+++ b/set_output_source.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
 
 from sys import argv
-from SwitchAudioSource import set_output
+from SwitchAudioSource import set_output, set_input, get_built_in_microphone, get_built_in_speaker
 
 query = argv[1]
+
 set_output(query)
+if (query == get_built_in_speaker()):
+  set_input(get_built_in_microphone())
+else:
+  set_input(query)


### PR DESCRIPTION
SwitchAudioSource has a new CLI version that is incompatible with the old 1.0.0 one.
This one resolves it and uses JSON Format instead of splitting strings