### PR TITLE
Automate Alfred Workflow publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Create Alfred Workflow
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build Alfred Workflow
+      id: alfred_builder
+      uses: mperezi/build-alfred-workflow@v1
+      with:
+        workflow_dir: .
+        exclude_patterns: '*.pyc *__pycache__/* *.git*'
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: ${{ github.ref }}
+        draft: false
+        prerelease: false
+    - name: Upload Alfred Workflow
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ steps.alfred_builder.outputs.workflow_file }}
+        asset_name: ${{ steps.alfred_builder.outputs.workflow_file }}
+        asset_content_type: application/zip


### PR DESCRIPTION
👋 I noticed that a fix for #8 already exists in the main branch, but this isn't published yet. To make life easier, I'd like to suggest using GitHub Actions to build the Alfred Workflow and create a release for tags matching `v*`.