### PR TITLE
Fix download link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,5 @@ Both commands have the ability to add a hotkey for quick access.
 
 [alfred]: https://www.alfredapp.com
 [switchaudio-osx]: https://github.com/deweller/switchaudio-osx
-[download-link]: https://github.com/alexlafroscia/alfred-switch-audio-source/releases/latest/download/Switch.Audio.alfredworkflow
+[download-link]: https://github.com/alexlafroscia/alfred-switch-audio-source/releases/latest/download/Switch-Audio-1.2.0.alfredworkflow
 [homebrew]: http://brew.sh


### PR DESCRIPTION
### Problem

The link to download the latest version in the README file doesn't work because the file name contains the version while the link does not. Clicking the link leads to a 404 error.

### Solution

Use the correct file name in the README file link.

### Comments

A better solution would the to fix the release's file name as it contains the wrong version (1.2.0 instead of 1.3.1).
