### PR TITLE
Adapt for macOS 12.3

### DIFF
--- a/SwitchAudioSource.py
+++ b/SwitchAudioSource.py
@@ -49,19 +49,21 @@ def get_sources():
 def get_current_output():
     command_output = check_output([
         PATH_TO_SWITCH_AUDIO, '-c', '-t', 'output', '-f', 'json' # being explicit, but should default to `-t output`
-    ]).replace("\n", "")
+    ]).decode('utf8')
     stdout.write(loads(command_output)["id"])
+
 
 def get_current_input():
     command_output = check_output([
         PATH_TO_SWITCH_AUDIO, '-c', '-t', 'input', '-f', 'json'
-    ]).replace("\n", "")
+    ]).decode('utf8')
     stdout.write(loads(command_output)["id"])
+
 
 def set_input(device):
     command_output = check_output([
         PATH_TO_SWITCH_AUDIO, '-i', device, '-t', 'input'
-    ]).capitalize()
+    ]).decode('utf8').capitalize()
     stdout.write(command_output)
 
 

--- a/get_current_input.py
+++ b/get_current_input.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from SwitchAudioSource import get_current_input
 

--- a/get_current_output.py
+++ b/get_current_output.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from SwitchAudioSource import get_current_output
 

--- a/list_sources.py
+++ b/list_sources.py
@@ -1,15 +1,14 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from sys import stdout, argv
 from json import dumps
 from SwitchAudioSource import get_sources
 
 
-output_items = filter(lambda source: source.type == argv[1], get_sources())
-items = map(lambda source: source.__dict__, output_items)
+items = [source.__dict__ for source in get_sources() if source.type == argv[1]]
 
 json_output = dumps({
-    "items": items
+    "items": list(items)
 })
 
 stdout.write(json_output)

--- a/set_input_source.py
+++ b/set_input_source.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from sys import argv
 from SwitchAudioSource import set_input

--- a/set_output_source.py
+++ b/set_output_source.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from sys import argv
 from SwitchAudioSource import set_output


### PR DESCRIPTION
Python 2 is no longer part of macOS. Use /usr/bin/env python3 instead.